### PR TITLE
fix: harden template loading and name generation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,10 +75,10 @@ fn validate_and_normalize_app_name(app_name: &str) -> Result<String, String> {
 }
 
 fn generate_app_names(app_name: &str) -> AppNames {
-    let sanitized_app_name = app_name.replace('-', "");
+    let sanitized_app_name = app_name.replace(['-', '_'], "");
     let app_name_lower = sanitized_app_name.to_lowercase();
     let app_name_pascal = app_name
-        .split('-')
+        .split(['-', '_'])
         .map(|part| {
             let mut chars = part.chars();
             chars

--- a/src/main.rs
+++ b/src/main.rs
@@ -150,35 +150,35 @@ fn create_directories(paths: &ProjectPaths) -> Result<(), String> {
 fn load_template_files(app_names: &AppNames) -> Result<ProjectFiles, String> {
     static TEMPLATES: Dir = include_dir!("$CARGO_MANIFEST_DIR/templates");
 
-    let get = |name: &str| -> &[u8] {
+    let get = |name: &str| -> Result<&[u8], String> {
         TEMPLATES
             .get_file(name)
-            .unwrap_or_else(|| panic!("Installation corrupted: missing {} template", name))
-            .contents()
+            .map(|file| file.contents())
+            .ok_or_else(|| format!("Installation corrupted: missing {} template", name))
     };
 
     // Get template files (these should always exist - if not, it's a broken installation)
     let package_json =
-        String::from_utf8_lossy(get("package.json")).replace("lowercase-name", &app_names.lower);
-    let package_lock_json = String::from_utf8_lossy(get("package-lock.json"))
+        String::from_utf8_lossy(get("package.json")?).replace("lowercase-name", &app_names.lower);
+    let package_lock_json = String::from_utf8_lossy(get("package-lock.json")?)
         .replace("lowercase-name", &app_names.lower)
         .into_bytes();
     let cdk_json =
-        String::from_utf8_lossy(get("cdk.json")).replace("lowercase-name", &app_names.lower);
-    let vitest_config = get("vitest.config.ts").to_vec();
-    let git_ignore = get(".gitignore").to_vec();
-    let bin_file = String::from_utf8_lossy(get("binfile.ts"))
+        String::from_utf8_lossy(get("cdk.json")?).replace("lowercase-name", &app_names.lower);
+    let vitest_config = get("vitest.config.ts")?.to_vec();
+    let git_ignore = get(".gitignore")?.to_vec();
+    let bin_file = String::from_utf8_lossy(get("binfile.ts")?)
         .replace("lowercase-name", &app_names.lower)
         .replace("pascalcase-name", &app_names.pascal);
     let lib_file =
-        String::from_utf8_lossy(get("libfile.ts")).replace("pascalcase-name", &app_names.pascal);
-    let src_file = get("srcfile.ts").to_vec();
-    let events_file = get("payload.json").to_vec();
-    let cdk_context = get("cdk.context.json").to_vec();
-    let test_file = get("index.test.ts").to_vec();
-    let ctx_file = get("contextfile.ts").to_vec();
-    let tsconfig = get("tsconfig.json").to_vec();
-    let biomeconfig = get("biome.json").to_vec();
+        String::from_utf8_lossy(get("libfile.ts")?).replace("pascalcase-name", &app_names.pascal);
+    let src_file = get("srcfile.ts")?.to_vec();
+    let events_file = get("payload.json")?.to_vec();
+    let cdk_context = get("cdk.context.json")?.to_vec();
+    let test_file = get("index.test.ts")?.to_vec();
+    let ctx_file = get("contextfile.ts")?.to_vec();
+    let tsconfig = get("tsconfig.json")?.to_vec();
+    let biomeconfig = get("biome.json")?.to_vec();
 
     Ok(ProjectFiles {
         package_json,


### PR DESCRIPTION
Two small robustness fixes to the scaffolding CLI.

**Graceful failure on missing templates**

`load_template_files` already returned a `Result`, but the internal `get` closure panicked when an embedded template was missing. The error now propagates through `Result`, so a corrupted installation fails the spinner and exits cleanly instead of printing a panic backtrace.

**Underscores as word separators**

Name generation only split on hyphens, so `my_test-app` produced `My_test-appStack` and package name `my_test-app`. Underscores are now treated like hyphens:

```
Before: my_test-app -> My_testAppStack / mytest_app
After:  my_test-app -> MyTestAppStack  / mytestapp
```