### PR TITLE
docs: update installation instructions for brew and shell installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,22 @@ Options:
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew install dreamorosi/tap/create-cdk-app
+```
+
+### Shell installer
+
+```bash
+curl --proto '=https' --tlsv1.2 -LsSf https://github.com/dreamorosi/create-cdk-app-cli/releases/latest/download/create-cdk-app-installer.sh | sh
+```
+
+Prebuilt binaries for Apple Silicon macOS and x64/ARM64 Linux are also available on the [releases page](https://github.com/dreamorosi/create-cdk-app-cli/releases/latest).
+
+### From source
+
 Clone the repository and run the following commands:
 
 ```bash


### PR DESCRIPTION
Update the README's installation section now that releases ship prebuilt binaries.

Leads with Homebrew (`brew install dreamorosi/tap/create-cdk-app`) and the shell installer (pointed at `releases/latest` so it never goes stale), links the releases page for direct downloads, and keeps the original cargo build path as a from-source option.